### PR TITLE
test: Cypress image - revert chrome version to 87

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node14.16.0-chrome89-ff86
+FROM cypress/browsers:node12.18.3-chrome87-ff82
 
 LABEL maintainer="jinjie" \
       description="Image used for running Cypress testing framework"


### PR DESCRIPTION
We are facing performance issue in Cypress 6.7.*/6.8.* with Chrome 89, so reverting Chrome version to 87 to validate the performance and compare.