### PR TITLE
Pin faker version and upgrade version Chrome to 96 and Firefox to 94

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node14.17.0-chrome91-ff89
+FROM cypress/browsers:node14.15.0-chrome96-ff94
 
 LABEL maintainer="jinjie" \
       description="Image used for running Cypress testing framework"
@@ -9,7 +9,7 @@ RUN npm install -g cypress mysql \
                    cypress-eslint-preprocessor \
                    cypress-promise \
                    cypress-xpath \
-                   eslint faker fs-extra moment prettier dotenv \
+                   eslint faker@5.5.3 fs-extra moment prettier dotenv \
                    lodash date-fns cypress-fail-fast
 
 COPY ./version-info /usr/bin


### PR DESCRIPTION
Due to DOS code in faker repo pointing to previous version and upgrading browser versions

More details - https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/