### PR TITLE
Create a new image to run Playwright tests for JS in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://gallery.ecr.aws/l5k6t5t7/cicd-images
 - Atlantis (`atlantis`)
 - Amazon Web Services CLI (`awscli`)
 - Cypress (`cypress`)
+- Playwright (`playwright`)
 - Docker-in-Docker (`dind`)
 - Google Kubernetes Engine CLI (`gkecli`)
 - Karma Test Runner (`karma`)
@@ -90,6 +91,17 @@ Canonical Tag: `cypress-<REPO_VERSION>` \
 Latest URL: `govtechsg/cicd-images:cypress-latest`
 
 ##### Notes
+
+#### `playwright`
+
+
+
+##### Notes
+
+- Playwright is an automation tool used for the integration tests (similar to Cypress)
+- We decided to use Playwright to simulate concurrent sessions which Cypress cannot simulate due to it's architectural limitation
+- This concurrent session tests are required to test the Singpass single active session rule
+- More info about Playwright: https://playwright.dev/docs/intro
 
 #### `dephash`
 

--- a/playwright/.publish.sh
+++ b/playwright/.publish.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+REPOSITORY_URL=$1;
+
+TAG="${REPOSITORY_URL}-next";
+TAG_LATEST="${REPOSITORY_URL}-latest";
+
+VERSIONS=$(docker run --entrypoint="version-info" ${TAG});
+echo $VERSIONS
+VERSION_CHROME=$(printf "${VERSIONS}" | grep chrome | cut -f 2 -d ':');
+VERSION_FIREFOX=$(printf "${VERSIONS}" | grep firefox | cut -f 2 -d ':');
+VERSION_PLAYWRIGHT=$(printf "${VERSIONS}" | grep playwright | cut -f 2 -d ':');
+EXISTENCE_TAG="${VERSION_PLAYWRIGHT}_chrome-${VERSION_CHROME}_firefox-${VERSION_FIREFOX}";
+EXISTENCE_REPO_URL="${REPOSITORY_URL}-${EXISTENCE_TAG}";
+
+printf "Checking existence of [${EXISTENCE_REPO_URL}]...";
+_="$(docker pull "${EXISTENCE_REPO_URL}")" && EXISTS=$?;
+if [[ "${EXISTS}" = "0" ]]  && [[ "$*" != *"--force"* ]]; then
+  printf "[${EXISTENCE_REPO_URL}] found. Skipping push.\n";
+  echo exists;
+else
+  printf "[${EXISTENCE_REPO_URL}] not found. Pushing new image...\n";
+  printf "Pushing [${TAG_LATEST}]... ";
+  docker tag ${TAG} ${TAG_LATEST};
+  docker push ${TAG_LATEST};
+  printf "Pushing [${EXISTENCE_REPO_URL}]... ";
+  docker tag ${TAG} ${EXISTENCE_REPO_URL};
+  docker push ${EXISTENCE_REPO_URL};
+fi;

--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -1,0 +1,13 @@
+FROM cypress/browsers:node14.15.0-chrome96-ff94
+
+LABEL maintainer="ramesh_bask" \
+      description="Image used for running concurrent sessions tests using Playwright"
+
+RUN npm install -g playwright
+RUN npx playwright install
+
+COPY ./version-info /usr/bin
+
+RUN chmod +x /usr/bin/version-info
+
+RUN npm link $(ls -1 $(npm root -g)/)

--- a/playwright/version-info
+++ b/playwright/version-info
@@ -1,0 +1,7 @@
+#!/bin/sh
+VERSION_CHROME="$(google-chrome --version | cut -d ' ' -f 3)";
+printf "chrome:${VERSION_CHROME}\n";
+VERSION_FIREFOX="$(firefox --version | cut -d ' ' -f 3)";
+printf "firefox:${VERSION_FIREFOX}\n";
+VERSION_PLAYWRIGHT="$(ls /root/.cache/ms-playwright)"
+printf "playwright:${VERSION_PLAYWRIGHT}\n";


### PR DESCRIPTION
- We are using Playwright automation tool for testing the concurrent sessions feature in Jobseeker.
- Since Playwright uses a different configuration, we cannot use the existing Cypress images that we use for our integration tests.
- Hence we need a new image that has just Playwright and it's browser deps. This image needs to be published to the ECR.