### PR TITLE
bump alpine base for several bases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 .history
 *.un~
 # End of https://www.gitignore.io/api/visualstudiocode
+
+## Jetbrain
+.idea

--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,4 +1,4 @@
-ARG alpine_ver=3.15.0
+ARG alpine_ver=3.15
 FROM alpine:${alpine_ver}
 LABEL maintainer="salihan" \
       description="Image containing Ansible and Ansible-lint for use in CI/CD pipelines"

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.10.3
-LABEL maintainer="gylsky <gylswork-at-gmail-com>" \
+FROM alpine:3.15
+LABEL maintainer="gyl <gylswork-at-gmail-com>" \
       description="Amazon Web Services CLI image for use in CI pipelines"
 ENV APK_DEPENDENCIES="bash curl git jq vim python3 make g++ docker" \
     PIP_DEPENDENCIES="awscli" \

--- a/dephash/Dockerfile
+++ b/dephash/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8.4
+FROM alpine:3.15
 LABEL maintainer="zephinzer <dev-at-joeir-dot-net>" \
       description="Dependency hasher image for use in CI containers"
 ENV APK_DEPENDENCIES="bash curl git jq vim" \

--- a/gkecli/Dockerfile
+++ b/gkecli/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.1
+FROM alpine:3.15
 LABEL description="Google Kubernetes Engine deployer image for use in CI pipelines"
 ARG GCLOUD_SDK_VERSION="177.0.0"
 ARG GCLOUD_SDK_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_SDK_VERSION}-linux-x86_64.tar.gz"

--- a/trinity/Dockerfile
+++ b/trinity/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.10.3
-LABEL maintainer="gylsky <gylswork-at-gmail-com" \
+FROM alpine:3.15
+LABEL maintainer="gyl <gylswork-at-gmail-com" \
       description="Amazon Web Services CLI image for use in CI pipelines"
 ENV APK_DEPENDENCIES="bash curl git jq vim python3 make g++ docker" \
     PIP_DEPENDENCIES="awscli" \

--- a/vtscripts/Dockerfile
+++ b/vtscripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8.4
+FROM alpine:3.15
 LABEL maintainer="zephinzer <dev-at-joeir-dot-net>" \
       description="Version tagger container for use in CI pipelines"
 ENV APK_DEPENDENCIES="bash curl git jq vim" \


### PR DESCRIPTION
Address CVE

|Severity & Vulnerability | Package | Version | Fixed in |
|-- | -- | -- | --|
| H | 9.1Out-of-bounds Read | CVE-2021-36159 | apk-tools | 2.10.4-r2 | 2.10.7-r0 |  
| H | 7.5Out-of-bounds Read | CVE-2021-30139 | apk-tools | 2.10.4-r2 | 2.10.6-r0

Bump all bases to 3.15 (remove patch version, latest available version now is 3.16)


