### PR TITLE
Add 1.19 to go-pact builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.15, 1.16, 1.17, 1.18]
+        go-version: [1.15, 1.16, 1.17, 1.18, 1.19]
     name: go-pact
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
1.19 just dropped at the start of Aug 🎉 