### PR TITLE
Fix playwright failed workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -367,7 +367,7 @@ jobs:
     name: playwright
     strategy:
       matrix:
-        node-version: [ 14.19.0, 16.14.2 ]
+        node-browser-version: [ 16.14.2-slim-chrome103-ff102 ]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
@@ -379,12 +379,12 @@ jobs:
       - name: Build and Publish
         if: "!contains(github.event.head_commit.message, '[force build]')"
         with:
-          docker_build_args: NODE_VERSION=${{ matrix.node-version }}
+          docker_build_args: NODE_BROWSER_VERSION=${{ matrix.node-browser-version }}
         uses: ./.github/actions/build-and-publish
       - name: Build and Publish (force)
         if: "contains(github.event.head_commit.message, '[force build]')"
         with:
-          docker_build_args: NODE_VERSION=${{ matrix.node-version }}
+          docker_build_args: NODE_BROWSER_VERSION=${{ matrix.node-browser-version }}
         uses: ./.github/actions/build-and-publish-force
 
   sqlplus:

--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -1,10 +1,10 @@
 # see build.yaml for actual version passed from pipeline
-ARG NODE_VERSION="14.19.0"
+ARG NODE_BROWSER_VERSION="16.14.2-slim-chrome103-ff102"
 
-FROM cypress/browsers:node${NODE_VERSION}-slim-chrome100-ff99-edge
+FROM cypress/browsers:node${NODE_BROWSER_VERSION}
 
 LABEL maintainer="ramesh_bask" \
-      description="Image used for running concurrent sessions tests using Playwright"
+      description="Image used for run Playwright testing framework"
 
 RUN npm install -g playwright
 RUN npx playwright install


### PR DESCRIPTION
`cypress/browsers` dockerhub does not have exact browser combos for different node version.

This PR allows exact node-browser version to be defined in workflow.