### PR TITLE
Upgrade Cypress browser to Chrome 107, firefox 107 with node 16.16.0 and pointing build to node 16 only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,7 +120,7 @@ jobs:
     name: cypress
     strategy:
       matrix:
-        node-version: [ 14.17.6, 16.14.2 ]
+        node-version: [ 16.16.0 ]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -1,7 +1,7 @@
 # see build.yaml for actual version passed from pipeline
-ARG NODE_VERSION="14.17.6"
+ARG NODE_VERSION="16.16.0"
 
-FROM cypress/browsers:node${NODE_VERSION}-slim-chrome100-ff99-edge
+FROM cypress/browsers:node${NODE_VERSION}-chrome107-ff107
 
 LABEL description="Image used for running Cypress testing framework"
 


### PR DESCRIPTION
Currently, there is no browser docker with node 14, so for now removing node 14 from the Cypress build which will be added later when available.