### PR TITLE
chore: Add 1.20 to go-pact builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.15, 1.16, 1.17, 1.18, 1.19]
+        go-version: [1.15, 1.16, 1.17, 1.18, 1.19, 1.20]
     name: go-pact
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Update go version in go-pact