### PR TITLE
updates: no more pushing to dockerhub (remove DH_REPO)

### DIFF
--- a/.github/actions/build-and-publish-force/action.yaml
+++ b/.github/actions/build-and-publish-force/action.yaml
@@ -10,7 +10,6 @@ runs:
   steps:
     - name: Build and publish force
       run: |
-        ./.scripts/.build.sh "${DH_REPO}" "${IMAGE_NAME}" "${{ inputs.docker_build_args}}" "${ECR_REPO}";
-        ./${IMAGE_NAME}/.publish.sh "${DH_REPO}:${IMAGE_NAME}" --force;
+        ./.scripts/.build.sh "${ECR_REPO}" "${IMAGE_NAME}" "${{ inputs.docker_build_args}}";
         ./${IMAGE_NAME}/.publish.sh "${ECR_REPO}:${IMAGE_NAME}" --force;
       shell: bash

--- a/.github/actions/build-and-publish/action.yaml
+++ b/.github/actions/build-and-publish/action.yaml
@@ -10,7 +10,6 @@ runs:
   steps:
     - name: Build and publish
       run: |
-        ./.scripts/.build.sh "${DH_REPO}" "${IMAGE_NAME}" "${{ inputs.docker_build_args}}" "${ECR_REPO}";
-        ./${IMAGE_NAME}/.publish.sh "${DH_REPO}:${IMAGE_NAME}";
+        ./.scripts/.build.sh "${ECR_REPO}" "${IMAGE_NAME}" "${{ inputs.docker_build_args}}";
         ./${IMAGE_NAME}/.publish.sh "${ECR_REPO}:${IMAGE_NAME}";
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ name: build and publish
 # events but only for the master branch
 on:
   push:
-    branches: [ master, 0323-remove-dockerhub-push ]
+    branches: [ master ]
   schedule:
     - cron:  '15 0 * * *'
   workflow_dispatch:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,6 @@ on:
 
 env:
   ECR_REPO: public.ecr.aws/l5k6t5t7/cicd-images
-  DH_REPO: govtechsg/cicd-images
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ name: build and publish
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 0323-remove-dockerhub-push ]
   schedule:
     - cron:  '15 0 * * *'
   workflow_dispatch:
@@ -32,8 +32,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -52,8 +50,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -72,8 +68,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -97,8 +91,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -124,8 +116,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -148,8 +138,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -168,8 +156,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -188,8 +174,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -211,8 +195,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -239,8 +221,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -263,8 +243,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -286,8 +264,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -310,8 +286,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -330,8 +304,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -350,8 +322,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -370,8 +340,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -390,8 +358,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -410,8 +376,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -430,8 +394,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish
@@ -450,8 +412,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Dockerhub login
-        run: docker login -u ${{ secrets.DH_USERNAME }} -p ${{ secrets.DH_PASSWORD }};
       - name: ECR public login
         run: /usr/local/bin/aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
       - name: Build and Publish

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is a collection of container images we use internally for contin
 
 Daily builds are run against these images and automatically sent to our public ECR repository at
 
-https://gallery.ecr.aws/l5k6t5t7/cicd-images
+https://gallery.ecr.aws/govtechsg/cicd-images/
 
 ## Catalog (Alphabetical Order)
 
@@ -32,10 +32,10 @@ https://gallery.ecr.aws/l5k6t5t7/cicd-images
 
 ### Release Notes
 
-The images are found in the [Public ECR](public.ecr.aws/l5k6t5t7/cicd-images), and the names of the
+The images are found in the [Public ECR](public.ecr.aws/govtechsg/cicd-images), and the names of the
 different types of images are added as a tag. For example given a type of image called `xyz`, it will be available under
-the repository URL `public.ecr.aws/l5k6t5t7/cicd-images:xyz-latest`. Specific versions can be found in
-https://gallery.ecr.aws/l5k6t5t7/cicd-images
+the repository URL `public.ecr.aws/govtechsg/cicd-images:xyz-latest`. Specific versions can be found in
+https://gallery.ecr.aws/govtechsg/cicd-images/
 
 ### Universal Tooling
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 ![Build and Publish](https://github.com/govtechsg/cicd-images/workflows/build%20and%20publish/badge.svg)
 
-This repository is a collection of Docker images we use internally for continuous integration/delivery pipelines.
+This repository is a collection of container images we use internally for continuous integration/delivery pipelines.
 
-Daily builds are run against these images and automatically sent to our DockerHub and the public ECR repository at
-
-https://hub.docker.com/r/govtechsg/cicd-images
+Daily builds are run against these images and automatically sent to our public ECR repository at
 
 https://gallery.ecr.aws/l5k6t5t7/cicd-images
 
@@ -34,10 +32,10 @@ https://gallery.ecr.aws/l5k6t5t7/cicd-images
 
 ### Release Notes
 
-The images are found in the [DockerHub registry](https://hub.docker.com/r/govtechsg/cicd-images), and the names of the
+The images are found in the [Public ECR](public.ecr.aws/l5k6t5t7/cicd-images), and the names of the
 different types of images are added as a tag. For example given a type of image called `xyz`, it will be available under
-the repository URL `govtechsg/cicd-images:xyz-latest`. Specific versions can be found in
-the [DockerHub Tags page](https://hub.docker.com/r/govtechsg/cicd-images/tags/)
+the repository URL `public.ecr.aws/l5k6t5t7/cicd-images:xyz-latest`. Specific versions can be found in
+https://gallery.ecr.aws/l5k6t5t7/cicd-images
 
 ### Universal Tooling
 
@@ -129,8 +127,8 @@ Latest URL: `govtechsg/cicd-images:dind-latest`
 
 ##### Notes
 
-You will need to configure this image so that the host file at path `/var/run/docker.sock` is mapped to
-the `/var/run/docker.sock` in the container.
+To use this image, you will need to configure this image so that the host file at path `/var/run/docker.sock` is mapped to
+the `/var/run/docker.sock` in the container. (This is a privilege mode and not recommended for production use.)
 
 - https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
 - https://www.develves.net/blogs/asd/2016-05-27-alternative-to-docker-in-docker/

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ This image helps to implement the load testing using K6. Check here for more inf
 
 ## Other Uses
 
+NOTE: Using Dockerhub flow for local testing, actual flow is using AWS ECR.
+
 Images specified here can be uploaded to other repositories if you so wish. The commands are:
 
 ### For Building


### PR DESCRIPTION
**CONTEXT**

Long time ago, pulling from dockerhub was no longer free flow and was heavily rate-limited, @ryanoolala added a separate container registry to public ECR (hosted in our general account)

**OBJECTIVE**

- officially sunsetting dockerhub (we will keep the account to prevent security issue)
- no new images will be pushed to dockerhub, old images will be kept for a while (until future revisit)
- people shall use public.ecr.aws/l5k6t5t7/cicd-images for new images

**CHANGE**

- remove the DH_REPO flow
- remove all dockerhub login
- remove dockerhub info from README.md
