### PR TITLE
Revert "Upgrade cypress node version to 18.17.1"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,7 +111,7 @@ jobs:
     name: cypress
     strategy:
       matrix:
-        node-version: [ 16.16.0, 18.17.1 ]
+        node-version: [ 16.16.0 ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
Reverts GovTechSG/cicd-images#85
Due to requirement differents in JS and EMP, we have to revert the current changes.