### PR TITLE
chores: bump pact ruby standalone from 1.19.0 to 2.0.7

### DIFF
--- a/go-pact-bullseye/Dockerfile
+++ b/go-pact-bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:${GOLANG_MAJOR_VERSION}-bullseye
 
 WORKDIR /opt
 
-ARG PACT_RUBY_STANDALONE_VERSION="1.91.0"
+ARG PACT_RUBY_STANDALONE_VERSION="2.0.7"
 RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v$PACT_RUBY_STANDALONE_VERSION/pact-$PACT_RUBY_STANDALONE_VERSION-linux-x86_64.tar.gz
 RUN tar xzf pact-$PACT_RUBY_STANDALONE_VERSION-linux-x86_64.tar.gz
 


### PR DESCRIPTION
We are upgrading the pact ruby standalone version to the current major version 2.x